### PR TITLE
Fixed: AudioFork not working in the latest versions of Asterisk (20.1…

### DIFF
--- a/app_audiofork.c
+++ b/app_audiofork.c
@@ -854,6 +854,7 @@ static int launch_audiofork_thread(
 		ast_verb(2, "<%s> [AudioFork] (%s) Setting TLS Cert: %s\n", ast_channel_name(chan), audiofork->direction_string, tcert);
 		struct ast_tls_config  *ast_tls_config;
 		audiofork->tls_cfg = ast_calloc(1, sizeof(*ast_tls_config));
+		audiofork->tls_cfg->enabled = 1;
 		audiofork->has_tls = 1;
 		ast_set_flag(&audiofork->tls_cfg->flags, AST_SSL_DONT_VERIFY_SERVER);
 	}


### PR DESCRIPTION
Recently, The Asterisk team made some large updates ARI allowing websockets to be used for the full application rather than only for events. They also added ground work for external media to use websockets (Not out yet, in RC). This caused the SSL connection to fail for AudioFork. Non SSL connections still work as expected.

After lots of digging it seems that if enabled is not set or 0 in the tls_cfg then Asterisk will not assign default ciphers. Meaning that the SSL connection fails.

After adding in `audiofork->tls_cfg->enabled = 1;` this seems to fix the problem, for me anyways. Hopefully this is the correct solution, but would love to hear your thoughts.

The affected Asterisk versions are: 20.14, 22.4.0

Here is the blog post regarding the latest changes: https://www.asterisk.org/ari-rest-over-websocket/